### PR TITLE
Link to website repo instead of aide repo.

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -13,10 +13,12 @@
 or error free.</strong>
 </p>
 <p>
-<strong>If you have any corrections, additions or constructive comments, please
-report them to the aide issue tracker
-<a href="https://github.com/aide/aide/issues">here</a>.
-</strong></p>
+<strong>
+If you have any corrections, additions or constructive comments, please report them to the
+<a href="https://github.com/aide/aide.github.io/issues">aide website issue tracker</a>, or
+<a href="https://github.com/aide/aide.github.io/pulls">create a pull request on the website's repository.</a>
+</strong>
+</p>
 <p>
 This document was originally written by Rami Lehti
 <a href="mailto:rammer@cs.tut.fi">&lt;rammer@cs.tut.fi&gt;</a>


### PR DESCRIPTION
Linking to the website's repository for issues and pull request made on the manual, instead of the main repository.

@hvhaugwitz thanks for reviewing :eyes: 