### PR TITLE
Remove IPCop

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
                 <li><a href="https://tracker.debian.org/pkg/aide">Debian GNU/Linux</a> | <a href="https://launchpad.net/ubuntu/+source/aide">Ubuntu</a>: <code>apt install aide</code></li>
                 <li><a href="http://www.freebsd.org/cgi/cvsweb.cgi/ports/security/aide/">FreeBSD</a>: <code>pkg install aide</code></li>
                 <li><a href="http://packages.gentoo.org/package/app-forensics/aide">Gentoo</a>: <code>emerge aide</code></li>
-                <li><a href="http://www.ipadd.de/binary-v2.html#ids">IPCop</a>: see <a href="http://www.ipadd.de/binary-v2.html#guide">here</a> for installation guidelines</li>
                 <li><a href="http://trac.macports.org/browser/trunk/dports/security/aide/Portfile">MacPorts</a>: <code>port install aide</code></li>
                 <li><a href="https://search.nixos.org/packages?show=aide&query=aide">NixOS</a>: <code>nix-env -iA nixos.aide</code></li>
                 <li>openSUSE: <code>zypper install aide</code></li>


### PR DESCRIPTION
ipadd.de is curently not the same as before. Accoridng to
http://web.archive.org/ - not working as intended for some years.