### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix the typo

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = gost

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/doc/index.html
+++ b/doc/index.html
@@ -534,7 +534,7 @@ that new files are created, config files of applications are edited,
 tons of small changes pile up until the report becomes
 unreadable. This can be avoided by updating the database once in a
 while. I myself run the update every night. But, I don't replace the
-input database nearly as often. The replacement of the input datbase
+input database nearly as often. The replacement of the input database
 should always be a manual operation. This should not be automated.
 </p>
 <p>


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

For me it was faster to do this (scripted) than to submit the typo fix ;-)