### PR TITLE
Add openSUSE Url

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 <li><a href="https://trac.macports.org/browser/trunk/dports/security/aide/Portfile">MacPorts</a>: <code>port install aide</code></li>
                 <li><a href="https://search.nixos.org/packages?show=aide&query=aide">NixOS</a>: <code>nix-env -iA nixos.aide</code></li>
                 <li><a href="https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/security/aide/">OpenBSD</a>: <code>pkg_add aide</code></li>
-                <li>openSUSE: <code>zypper install aide</code></li>
+                <li><a href="https://software.opensuse.org/package/aide">openSUSE</a> | SUSE: <code>zypper install aide</code></li>
                 <li>Red Hat | CentOS | Fedora: <code>yum install aide</code></li>
             </ul>
             <small>See also the output of <code>whohas aide</code>.</small>


### PR DESCRIPTION
Add a link to AIDE's package page at software.opensuse.org.